### PR TITLE
Define LEDSTRIP_LENGTH with size 7

### DIFF
--- a/rainbowhat/src/main/java/com/google/android/things/contrib/driver/rainbowhat/RainbowHat.java
+++ b/rainbowhat/src/main/java/com/google/android/things/contrib/driver/rainbowhat/RainbowHat.java
@@ -52,6 +52,7 @@ public class RainbowHat {
     public static final String LED_RED = "BCM6";
     public static final String LED_GREEN = "BCM19";
     public static final String LED_BLUE = "BCM26";
+    public static final int LEDSTRIP_LENGTH = 7;
 
     public static Bmx280 openSensor() throws IOException {
         return new Bmx280(BUS_SENSOR);


### PR DESCRIPTION
This PR adds a constant value LEDSTRIP_LENGTH to the rainbowhat drivers.

That value is used in the Readme.md samples and it matchs the number of leds present in the rainbow.

There's an issue opened about this topic https://github.com/androidthings/contrib-drivers/issues/4

