### PR TITLE
[driver] Add simple driver for WS2801 RGB LED strip

### DIFF
--- a/ws2801/.driver-metadata
+++ b/ws2801/.driver-metadata
@@ -1,0 +1,1 @@
+TYPE="RGB LED strip"

--- a/ws2801/README.md
+++ b/ws2801/README.md
@@ -1,0 +1,78 @@
+WS2801 LED driver for Android Things
+====================================
+
+This driver supports RGB LED peripherals built on the WS2801 SPI protocol.
+
+NOTE: these drivers are not production-ready. They are offered as sample
+implementations of Android Things user space drivers for common peripherals
+as part of the Developer Preview release. There is no guarantee
+of correctness, completeness or robustness.
+
+How to use the driver
+---------------------
+
+### Gradle dependency
+
+To use the `ws2801` driver, simply add the line below to your project's `build.gradle`,
+where `<version>` matches the last version of the driver available on [jcenter][jcenter].
+
+```
+dependencies {
+    compile 'com.google.android.things.contrib:driver-ws2801:<version>'
+}
+```
+
+### Sample usage
+
+```java
+import com.google.android.things.contrib.driver.ws2801.Ws2801;
+
+// Access the LED strip:
+
+Ws2801 mWs2801;
+
+try {
+    mWs2801 = new Ws2801(spiBusName, Ws2801.Mode.RGB);
+} catch (IOException e) {
+    // couldn't configure the device...
+}
+
+// Light it up!
+
+int[] colors = new int[] {Color.RED};
+try {
+    mWs2801.write(colors);
+} catch (IOException e) {
+    // error setting LEDs
+}
+
+// Close the LED strip when finished:
+
+try {
+    mWs2801.close();
+} catch (IOException e) {
+    // error closing LED strip
+}
+```
+
+License
+-------
+
+Copyright 2016 Google Inc.
+
+Licensed to the Apache Software Foundation (ASF) under one or more contributor
+license agreements.  See the NOTICE file distributed with this work for
+additional information regarding copyright ownership.  The ASF licenses this
+file to you under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy of
+the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+
+[jcenter]: https://bintray.com/google/androidthings/contrib-driver-ws2801/_latestVersion

--- a/ws2801/build.gradle
+++ b/ws2801/build.gradle
@@ -14,16 +14,24 @@
  * limitations under the License.
  */
 
-include ':apa102'
-include ':button'
-include ':bmx280'
-include ':cap12xx'
-include ':gps'
-include ':ht16k33'
-include ':mma7660fc'
-include ':pwmservo'
-include ':pwmspeaker'
-include ':tm1637'
-include ':ssd1306'
-include ':rainbowhat'
-include ':ws2801'
+apply plugin: 'com.android.library'
+
+android {
+    compileSdkVersion 24
+    buildToolsVersion '24.0.3'
+
+    defaultConfig {
+        minSdkVersion 24
+        targetSdkVersion 24
+        versionCode 1
+        versionName "1.0"
+    }
+}
+
+dependencies {
+    provided 'com.google.android.things:androidthings:0.1-devpreview'
+    testCompile 'junit:junit:4.12'
+    testCompile 'org.mockito:mockito-all:1.10.19'
+    testCompile 'org.powermock:powermock-module-junit4:1.6.6'
+    testCompile 'org.powermock:powermock-api-mockito:1.6.6'
+}

--- a/ws2801/publish.gradle
+++ b/ws2801/publish.gradle
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  To publish on Bintray:
+ *  - set environmental variables BINTRAY_USER and BINTRAY_API_KEY to proper values
+ *  - from this directory:
+ *     ../gradlew -b publish.gradle bintrayUpload
+ *
+ */
+
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:2.2.1'
+    }
+}
+
+plugins {
+    id "com.jfrog.bintray" version "1.7"
+}
+
+allprojects {
+    repositories {
+        jcenter()
+    }
+}
+
+apply from: 'build.gradle'
+apply plugin: 'maven-publish'
+
+def packageVersion = '0.1'
+
+task sourceJar(type: Jar) {
+    classifier = 'sources'
+    from android.sourceSets.main.java.sourceFiles
+}
+
+publishing {
+    publications {
+        driverPublish(MavenPublication) {
+            groupId 'com.google.android.things.contrib'
+            artifactId "driver-$project.name"
+            version packageVersion
+            artifacts = configurations.archives.artifacts
+            artifact sourceJar
+            pom.withXml {
+                def dependenciesNode = asNode().appendNode('dependencies')
+                configurations.compile.allDependencies.each {
+                    if(it.group != null && (it.name != null || "unspecified".equals(it.name)) && it.version != null)
+                    {
+                        def dependencyNode = dependenciesNode.appendNode('dependency')
+                        dependencyNode.appendNode('groupId', it.group)
+                        dependencyNode.appendNode('artifactId', it.name)
+                        dependencyNode.appendNode('version', it.version)
+                    }
+                }
+            }
+        }
+    }
+}
+
+bintray {
+  user = System.getenv('BINTRAY_USER')
+  key = System.getenv('BINTRAY_API_KEY')
+  publications = ['driverPublish']
+
+  publish = true
+
+  pkg {
+    repo = 'androidthings'
+    name = "contrib-driver-$project.name"
+    userOrg = 'google'
+
+    version {
+      name = packageVersion
+      gpg {
+        sign = true
+      }
+    }
+  }
+}

--- a/ws2801/src/main/AndroidManifest.xml
+++ b/ws2801/src/main/AndroidManifest.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ Copyright 2016 Google Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.google.android.things.contrib.driver.ws2801">
+    <application>
+        <uses-library android:name="com.google.android.things"/>
+    </application>
+</manifest>

--- a/ws2801/src/main/java/com/google/android/things/contrib/driver/ws2801/Ws2801.java
+++ b/ws2801/src/main/java/com/google/android/things/contrib/driver/ws2801/Ws2801.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.things.contrib.driver.ws2801;
+
+import android.graphics.Color;
+
+import com.google.android.things.pio.PeripheralManagerService;
+import com.google.android.things.pio.SpiDevice;
+
+import java.io.IOException;
+
+/**
+ * Device driver for WS2801 RGB LEDs using 2-wire SPI.
+ * <p>
+ * For more information on SPI, see:
+ * https://en.wikipedia.org/wiki/Serial_Peripheral_Interface_Bus
+ * For information on the WS2801 protocol, see:
+ * https://cdn-shop.adafruit.com/datasheets/WS2801.pdf
+ */
+
+@SuppressWarnings({"unused", "WeakerAccess"})
+public class Ws2801 implements AutoCloseable {
+    private static final String TAG = "Ws2801";
+
+    /**
+     * Color ordering for the RGB LED messages; the most common modes are BGR and RGB.
+     */
+    public enum Mode {
+        RGB,
+        RBG,
+        GRB,
+        GBR,
+        BRG,
+        BGR
+    }
+
+    public enum Direction {
+        NORMAL,
+        REVERSED,
+    }
+
+    // RGB LED strip configuration that must be provided by the caller.
+    private Mode mLedMode;
+
+    // Direction of the led strip;
+    private Direction mDirection;
+
+    // Device SPI Configuration constants
+    private static final int WS2801_PACKET_LENGTH = 3;
+    private static final int SPI_BPW = 8; // Bits per word
+    private static final int SPI_FREQUENCY = 1000000;
+    private static final int SPI_MODE = SpiDevice.MODE0; // Mode 0 seems to work best for WS2801
+
+    // For peripherals access
+    private SpiDevice mDevice = null;
+
+    /**
+     * Create a new Ws2801 driver.
+     *
+     * @param spiBusPort Name of the SPI bus
+     * @param ledMode    The {@link Mode} indicating the red/green/blue byte ordering for the device.
+     */
+    public Ws2801(String spiBusPort, Mode ledMode) throws IOException {
+        this(spiBusPort, ledMode, Direction.NORMAL);
+    }
+
+    /**
+     * Create a new Ws2801 driver.
+     *
+     * @param spiBusPort Name of the SPI bus
+     * @param ledMode    The {@link Mode} indicating the red/green/blue byte ordering for the device.
+     * @param direction  The {@link Direction} or the led strip.
+     */
+    public Ws2801(String spiBusPort, Mode ledMode, Direction direction) throws IOException {
+        mLedMode = ledMode;
+        mDirection = direction;
+        PeripheralManagerService pioService = new PeripheralManagerService();
+        mDevice = pioService.openSpiDevice(spiBusPort);
+        try {
+            configure(mDevice);
+        } catch (IOException | RuntimeException e) {
+            try {
+                close();
+            } catch (IOException | RuntimeException ignored) {
+            }
+            throw e;
+        }
+    }
+
+    /**
+     * Create a new Ws2801 driver.
+     *
+     * @param device  {@link SpiDevice} where the LED strip is attached to.
+     * @param ledMode The {@link Mode} indicating the red/green/blue byte ordering for the device.
+     */
+    /*package*/ Ws2801(SpiDevice device, Mode ledMode, Direction direction) throws IOException {
+        mLedMode = ledMode;
+        mDirection = direction;
+        mDevice = device;
+        configure(mDevice);
+    }
+
+    private void configure(SpiDevice device) throws IOException {
+        // Note: You may need to set bit justification for your board.
+        // mDevice.setBitJustification(SPI_BITJUST);
+        device.setFrequency(SPI_FREQUENCY);
+        device.setMode(SPI_MODE);
+        device.setBitsPerWord(SPI_BPW);
+    }
+
+    /**
+     * Writes the current RGB Led data to the peripheral bus.
+     *
+     * @param colors An array of integers corresponding to a {@link Color}.
+     * @throws IOException
+     */
+    public void write(int[] colors) throws IOException {
+        byte[] ledData = new byte[WS2801_PACKET_LENGTH * colors.length];
+
+        // Compute the packets to send.
+        for (int i = 0; i < colors.length; i++) {
+            int outputPosition = i * WS2801_PACKET_LENGTH;
+            int di = mDirection == Direction.NORMAL ? i : colors.length - i - 1;
+            System.arraycopy(getWsColorData(colors[di]), 0, ledData, outputPosition, WS2801_PACKET_LENGTH);
+        }
+
+        mDevice.write(ledData, ledData.length);
+    }
+
+    /**
+     * Releases the SPI interface and related resources.
+     */
+    @Override
+    public void close() throws IOException {
+        if (mDevice != null) {
+            try {
+                mDevice.close();
+            } finally {
+                mDevice = null;
+            }
+        }
+    }
+
+    /**
+     * Returns an WS2801 packet corresponding to the current brightness and given {@link Color}.
+     *
+     * @param color The {@link Color} to retrieve the protocol packet for.
+     * @return WS2801 packet corresponding to the current brightness and given {@link Color}.
+     */
+    private byte[] getWsColorData(int color) {
+        int r = Color.red(color);
+        int g = Color.green(color);
+        int b = Color.blue(color);
+
+        switch (mLedMode) {
+            case RBG:
+                return new byte[]{(byte) r, (byte) b, (byte) g};
+            case BGR:
+                return new byte[]{(byte) b, (byte) g, (byte) r};
+            case BRG:
+                return new byte[]{(byte) b, (byte) r, (byte) g};
+            case GRB:
+                return new byte[]{(byte) g, (byte) r, (byte) b};
+            case GBR:
+                return new byte[]{(byte) g, (byte) b, (byte) r};
+            default:
+                // RGB
+                return new byte[]{(byte) r, (byte) g, (byte) b};
+        }
+    }
+}

--- a/ws2801/src/test/java/com/google/android/things/contrib/driver/ws2801/BytesMatcher.java
+++ b/ws2801/src/test/java/com/google/android/things/contrib/driver/ws2801/BytesMatcher.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.things.contrib.driver.ws2801;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+
+import java.util.Arrays;
+
+public class BytesMatcher extends BaseMatcher<byte[]> {
+    private byte[] mExpectedBytes;
+
+    BytesMatcher(byte[] expectedBytes) {
+        mExpectedBytes = expectedBytes;
+    }
+
+    public static BytesMatcher contains(byte... expectedBytes) {
+        return new BytesMatcher(expectedBytes);
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText(Arrays.toString(mExpectedBytes));
+    }
+
+    @Override
+    public boolean matches(Object item) {
+        byte[] spiData = (byte[]) item;
+        for (int i = 0; i < spiData.length - mExpectedBytes.length + 1; i++) {
+            int j;
+            for (j = 0; j < mExpectedBytes.length; j++) {
+                if (spiData[i+j] != mExpectedBytes[j]) {
+                    break;
+                }
+            }
+            if (j == mExpectedBytes.length) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/ws2801/src/test/java/com/google/android/things/contrib/driver/ws2801/BytesMatcherTest.java
+++ b/ws2801/src/test/java/com/google/android/things/contrib/driver/ws2801/BytesMatcherTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.things.contrib.driver.ws2801;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+
+public class BytesMatcherTest {
+    @Test
+    public void match() throws IOException {
+        BytesMatcher bm = new BytesMatcher("foo".getBytes());
+        assertFalse(bm.matches("fo".getBytes()));
+        assertTrue(bm.matches("foo".getBytes()));
+        assertTrue(bm.matches("hopfoobar".getBytes()));
+        assertFalse(bm.matches("noneofthose".getBytes()));
+    }
+
+    @Test
+    public void matchEmpty() throws IOException {
+        BytesMatcher bm = new BytesMatcher("".getBytes());
+        assertTrue(bm.matches("foo".getBytes()));
+    }
+
+}

--- a/ws2801/src/test/java/com/google/android/things/contrib/driver/ws2801/ColorMock.java
+++ b/ws2801/src/test/java/com/google/android/things/contrib/driver/ws2801/ColorMock.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.things.contrib.driver.ws2801;
+
+import android.graphics.Color;
+
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+
+public class ColorMock {
+    public static void mockStatic() {
+        PowerMockito.mockStatic(Color.class);
+        Mockito.when(Color.red(Mockito.anyInt())).thenAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                int c = invocation.getArgumentAt(0, Integer.class);
+                return c >> 16 & 0xff;
+            }
+        });
+        Mockito.when(Color.green(Mockito.anyInt())).thenAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                int c = invocation.getArgumentAt(0, Integer.class);
+                return c >> 8 & 0xff;
+            }
+        });
+        Mockito.when(Color.blue(Mockito.anyInt())).thenAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                int c = invocation.getArgumentAt(0, Integer.class);
+                return c & 0xff;
+            }
+        });
+    }
+}

--- a/ws2801/src/test/java/com/google/android/things/contrib/driver/ws2801/Ws2801Test.java
+++ b/ws2801/src/test/java/com/google/android/things/contrib/driver/ws2801/Ws2801Test.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.things.contrib.driver.ws2801;
+
+import com.google.android.things.pio.SpiDevice;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.IOException;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(android.graphics.Color.class)
+public class Ws2801Test {
+
+    @Mock
+    SpiDevice mSpiDevice;
+
+    @Rule
+    public MockitoRule mMockitoRule = MockitoJUnit.rule();
+
+    @Rule
+    public ExpectedException mExpectedException = ExpectedException.none();
+
+    @Test
+    public void write() throws IOException {
+        ColorMock.mockStatic();
+        Ws2801 leds = new Ws2801(mSpiDevice, Ws2801.Mode.BGR, Ws2801.Direction.NORMAL);
+        final int[] colors = {0xff00ff, 0x00ff00, 0x0000ff};
+        leds.write(colors);
+        Mockito.verify(mSpiDevice).write(Mockito.argThat(BytesMatcher.contains(
+                (byte)(colors[0]&0xff), (byte)(colors[0]>>8&0xff), (byte)(colors[0]>>16&0xff),
+                (byte)(colors[1]&0xff), (byte)(colors[1]>>8&0xff), (byte)(colors[1]>>16&0xff),
+                (byte)(colors[2]&0xff), (byte)(colors[2]>>8&0xff), (byte)(colors[2]>>16&0xff)
+        )), Mockito.eq(colors.length*3));
+    }
+
+    @Test
+    public void write_reversed() throws IOException {
+        ColorMock.mockStatic();
+        Ws2801 leds = new Ws2801(mSpiDevice, Ws2801.Mode.BGR, Ws2801.Direction.REVERSED);
+        final int[] colors = {0xff0000, 0x00ff00, 0x0000ff};
+        leds.write(colors);
+        Mockito.verify(mSpiDevice).write(Mockito.argThat(BytesMatcher.contains(
+                (byte)(colors[2]&0xff), (byte)(colors[2]>>8&0xff), (byte)(colors[2]>>16&0xff),
+                (byte)(colors[1]&0xff), (byte)(colors[1]>>8&0xff), (byte)(colors[1]>>16&0xff),
+                (byte)(colors[0]&0xff), (byte)(colors[0]>>8&0xff), (byte)(colors[0]>>16&0xff)
+        )), Mockito.eq(colors.length*3));
+    }
+}


### PR DESCRIPTION
I've added a simple driver for the WS2801 RGB LED strip. It may work for some other variations but I've only tested it with the WS2801: https://cdn-shop.adafruit.com/datasheets/WS2801.pdf

As you can see the protocol is simpler than the Apa102 one since we only have to send 3 (red, green and blue) bytes for every LED, so we don't need to send extra bytes for the brightness or for signalling the beginning and end of a sequence. In order to define brightness we just need to send a lower or higher value for that color (the higher the value, the more bright that color will be).

This is literally a copy of the `apa102` folder and I just replaced the name with `ws2801` and modified the driver class along with the tests. Unit tests pass and I also tested with a strip I have at home and it works 🎉 (and I also made a demo app in order to test it myself that can be found [here](https://github.com/xrigau/androidthings-rgb-led/tree/master/app/src/main/java/com/xavirigau/ledcontroller))