### PR TITLE
Replace invalid method name in pwmservo README

### DIFF
--- a/pwmservo/README.md
+++ b/pwmservo/README.md
@@ -33,8 +33,8 @@ Servo mServo;
 
 try {
     mServo = new Servo(pwmPinName);
-    mServo.setPulseWidthDurationRange(1, 2); // according to your servo's specifications
-    mServo.setAngleRange(0, 180);            // according to your servo's specifications
+    mServo.setPulseDurationRange(1, 2); // according to your servo's specifications
+    mServo.setAngleRange(0, 180);       // according to your servo's specifications
     mServo.setEnabled(true);
 } catch (IOException e) {
     // couldn't configure the servo...


### PR DESCRIPTION
Servo's `setPulseWidthDurationRange` method does not exist.
Update README so it is referencing to `setPulseDurationRange` instead.