### PR TITLE
Optional param for I2C address in constructor

### DIFF
--- a/ssd1306/publish.gradle
+++ b/ssd1306/publish.gradle
@@ -44,7 +44,7 @@ allprojects {
 apply from: 'build.gradle'
 apply plugin: 'maven-publish'
 
-def packageVersion = '0.1'
+def packageVersion = '0.2'
 
 task sourceJar(type: Jar) {
     classifier = 'sources'

--- a/ssd1306/src/main/java/com/google/android/things/contrib/driver/ssd1306/Ssd1306.java
+++ b/ssd1306/src/main/java/com/google/android/things/contrib/driver/ssd1306/Ssd1306.java
@@ -41,7 +41,7 @@ public class Ssd1306 implements Closeable {
      * I2C address for this peripheral
      */
     public static final int I2C_ADDRESS = 0x3C;
-    public static final int I2C_ADDRESS_SECONDARY = 0x3D;
+    public static final int I2C_ADDRESS_ALT = 0x3D;
 
     // Protocol constants
     private static final int COMMAND_ACTIVATE_SCROLL = 0x2F;
@@ -110,7 +110,7 @@ public class Ssd1306 implements Closeable {
     /**
      * Create a new Ssd1306 driver connected to the named I2C bus and address
      * @param i2cName I2C bus name the display is connected to
-     * @param i2cAddress I2C address the display is connected to
+     * @param i2cAddress I2C address of the display
      * @throws IOException
      */
     public Ssd1306(String i2cName, int i2cAddress) throws IOException {

--- a/ssd1306/src/main/java/com/google/android/things/contrib/driver/ssd1306/Ssd1306.java
+++ b/ssd1306/src/main/java/com/google/android/things/contrib/driver/ssd1306/Ssd1306.java
@@ -41,6 +41,7 @@ public class Ssd1306 implements Closeable {
      * I2C address for this peripheral
      */
     public static final int I2C_ADDRESS = 0x3C;
+    public static final int I2C_ADDRESS_SECONDARY = 0x3D;
 
     // Protocol constants
     private static final int COMMAND_ACTIVATE_SCROLL = 0x2F;
@@ -103,7 +104,17 @@ public class Ssd1306 implements Closeable {
      * @throws IOException
      */
     public Ssd1306(String i2cName) throws IOException {
-        I2cDevice device = new PeripheralManagerService().openI2cDevice(i2cName, I2C_ADDRESS);
+        this(i2cName, I2C_ADDRESS);
+    }
+
+    /**
+     * Create a new Ssd1306 driver connected to the named I2C bus and address
+     * @param i2cName I2C bus name the display is connected to
+     * @param i2cAddress I2C address the display is connected to
+     * @throws IOException
+     */
+    public Ssd1306(String i2cName, int i2cAddress) throws IOException {
+        I2cDevice device = new PeripheralManagerService().openI2cDevice(i2cName, i2cAddress);
         try {
             init(device);
         } catch (IOException | RuntimeException e) {


### PR DESCRIPTION
I've been playing with a board I made featuring two of these ssd1306 oled screens on it. The version I have can have it's I2C address changed by bridging two contacts on the back, allowing there to be two separate screens to draw to simultaneously.

This pr adds another constructor that takes a given I2C address to communicate with. The existing constructor defaults to the address that was already in place.