### PR TITLE
Change createButtonInputDriver visibility to public

### DIFF
--- a/rainbowhat/src/main/java/com/google/android/things/contrib/driver/rainbowhat/RainbowHat.java
+++ b/rainbowhat/src/main/java/com/google/android/things/contrib/driver/rainbowhat/RainbowHat.java
@@ -78,7 +78,7 @@ public class RainbowHat {
         return new Button(pin, BUTTON_LOGIC_STATE);
     }
 
-    static ButtonInputDriver createButtonInputDriver(@ButtonPin String pin, int keycode) throws IOException {
+    public static ButtonInputDriver createButtonInputDriver(@ButtonPin String pin, int keycode) throws IOException {
         return new ButtonInputDriver(pin, BUTTON_LOGIC_STATE, keycode);
     }
 


### PR DESCRIPTION
RainbowHat.`createButtonInputDriver` cannot be accessed from outside package.
Change its visibility to public.
