### PR TITLE
Ap102 SPI Mode use the constant from the SDK

### DIFF
--- a/apa102/src/main/java/com/google/android/things/contrib/driver/apa102/Apa102.java
+++ b/apa102/src/main/java/com/google/android/things/contrib/driver/apa102/Apa102.java
@@ -75,7 +75,7 @@ public class Apa102 implements AutoCloseable {
     // Device SPI Configuration constants
     private static final int SPI_BPW = 8; // Bits per word
     private static final int SPI_FREQUENCY = 1000000;
-    private static final int SPI_MODE = 2;
+    private static final int SPI_MODE = SpiDevice.MODE2;
 
     // Protocol constants for APA102c
     private static final int APA_PACKET_LENGTH = 4;


### PR DESCRIPTION
Uses the AndroidThings SDK constant to avoid confusion when people read the source code.