### PR TITLE
gps: Fix typo on README.md - init NmeaGpsModule

### DIFF
--- a/gps/README.md
+++ b/gps/README.md
@@ -37,7 +37,6 @@ NmeaGpsModule mGpsModule;
 
 try {
     mGpsModule = new NmeaGpsModule(
-            this,           // context
             uartPortName,
             baudRate        // specified baud rate for your GPS peripheral
     );


### PR DESCRIPTION
The constructor of `NmeaGpsModule` class doesn't receive a context param, it's the `NmeaGpsDriver` class that need this param.