### PR TITLE
adding in the ability to set the contrast on the ssd1306

### DIFF
--- a/ssd1306/build.gradle
+++ b/ssd1306/build.gradle
@@ -30,4 +30,7 @@ android {
 
 dependencies {
     provided 'com.google.android.things:androidthings:0.4-devpreview'
+
+    testCompile 'org.powermock:powermock-module-junit4:1.6.6'
+    testCompile 'org.powermock:powermock-api-mockito:1.6.6'
 }

--- a/ssd1306/src/main/java/com/google/android/things/contrib/driver/ssd1306/Ssd1306.java
+++ b/ssd1306/src/main/java/com/google/android/things/contrib/driver/ssd1306/Ssd1306.java
@@ -53,6 +53,7 @@ public class Ssd1306 implements Closeable {
     private static final int COMMAND_DISPLAY_ON = 0xAF;
     private static final int COMMAND_DISPLAY_OFF = 0xAE;
     private static final int COMMAND_START_LINE = 0x40;
+    private static final int COMMAND_CONTRAST_LEVEL = 0x81;
     private static final int DATA_OFFSET = 1;
     private static final int INIT_CHARGE_PUMP = 0x8D;
     private static final int INIT_CLK_DIV = 0xD5;
@@ -235,6 +236,19 @@ public class Ssd1306 implements Closeable {
         } else {
             mBuffer[DATA_OFFSET + x + ((y / 8) * mWidth)] &= ~(1 << y % 8);
         }
+    }
+
+    /**
+     * Sets the contrast for the display.
+     *
+     * @param level The contrast level (0-255).
+     */
+    public void setContrast(int level) throws IOException, IllegalArgumentException {
+        if (level < 0 || level > 255) {
+            throw new IllegalArgumentException("contrast out of bound:" + level);
+        }
+        mI2cDevice.writeRegByte(0, (byte) COMMAND_CONTRAST_LEVEL );
+        mI2cDevice.writeRegByte(0, (byte) level );
     }
 
     /**

--- a/ssd1306/src/main/java/com/google/android/things/contrib/driver/ssd1306/Ssd1306.java
+++ b/ssd1306/src/main/java/com/google/android/things/contrib/driver/ssd1306/Ssd1306.java
@@ -242,8 +242,13 @@ public class Ssd1306 implements Closeable {
      * Sets the contrast for the display.
      *
      * @param level The contrast level (0-255).
+     * @throws IllegalStateException
+     * @throws IllegalArgumentException
      */
     public void setContrast(int level) throws IOException, IllegalArgumentException {
+        if (mI2cDevice == null) {
+            throw new IllegalStateException("I2C Device not open");
+        }
         if (level < 0 || level > 255) {
             throw new IllegalArgumentException("Invalid contrast " + String.valueOf(level) +
                     ", level must be between 0 and 255");

--- a/ssd1306/src/main/java/com/google/android/things/contrib/driver/ssd1306/Ssd1306.java
+++ b/ssd1306/src/main/java/com/google/android/things/contrib/driver/ssd1306/Ssd1306.java
@@ -245,11 +245,13 @@ public class Ssd1306 implements Closeable {
      */
     public void setContrast(int level) throws IOException, IllegalArgumentException {
         if (level < 0 || level > 255) {
-            throw new IllegalArgumentException("contrast out of bound:" + level);
+            throw new IllegalArgumentException("Invalid contrast " + String.valueOf(level) +
+                    ", level must be between 0 and 255");
         }
-        mI2cDevice.writeRegByte(0, (byte) COMMAND_CONTRAST_LEVEL );
-        mI2cDevice.writeRegByte(0, (byte) level );
+        mI2cDevice.writeRegByte(0, (byte) COMMAND_CONTRAST_LEVEL);
+        mI2cDevice.writeRegByte(0, (byte) level);
     }
+
 
     /**
      * Turns the display on and off.

--- a/ssd1306/src/test/java/com/google/android/things/contrib/driver/ssd1306/Ssd1306Test.java
+++ b/ssd1306/src/test/java/com/google/android/things/contrib/driver/ssd1306/Ssd1306Test.java
@@ -17,6 +17,9 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.IOException;
 
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.withSettings;
+import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
@@ -63,5 +66,13 @@ public class Ssd1306Test {
             Mockito.verify(mI2c, Mockito.never()).writeRegByte(0x00, (byte) 66);
             Mockito.reset(mExpectedException);
         }
+    }
+
+    @Test
+    public void nullmI2cDevice() throws IOException {
+        Ssd1306 ssd1306 = mock(Ssd1306.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
+        mExpectedException.expect(IllegalStateException.class);
+        mExpectedException.expectMessage("I2C Device not open");
+        ssd1306.setContrast(44);
     }
 }

--- a/ssd1306/src/test/java/com/google/android/things/contrib/driver/ssd1306/Ssd1306Test.java
+++ b/ssd1306/src/test/java/com/google/android/things/contrib/driver/ssd1306/Ssd1306Test.java
@@ -1,0 +1,67 @@
+package com.google.android.things.contrib.driver.ssd1306;
+
+import android.graphics.Bitmap;
+
+import com.google.android.things.pio.I2cDevice;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.IOException;
+
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({BitmapHelper.class, Bitmap.class})
+public class Ssd1306Test {
+
+    @Mock
+    I2cDevice mI2c;
+
+    @Rule
+    public MockitoRule mMokitoRule = MockitoJUnit.rule();
+
+    @Rule
+    public ExpectedException mExpectedException = ExpectedException.none();
+
+    @Test
+    public void setContrastValidValues() throws IOException {
+        mockStatic(BitmapHelper.class);
+        mockStatic(Bitmap.class);
+        Ssd1306 ssd1306 = new Ssd1306(mI2c);
+
+        int[] validValues = {0, 66, 255};
+
+        for (int validValue : validValues) {
+            ssd1306.setContrast(validValue);
+            Mockito.verify(mI2c).writeRegByte(0x00, (byte) 0x81);
+            Mockito.verify(mI2c).writeRegByte(0x00, (byte) validValue);
+            Mockito.reset(mI2c);
+        }
+    }
+
+    @Test
+    public void setContrastInValidValues() throws IOException {
+        int[] invalidValues = {-777, -1, 256, 999};
+        mockStatic(BitmapHelper.class);
+        mockStatic(Bitmap.class);
+        Ssd1306 ssd1306 = new Ssd1306(mI2c);
+
+        for (int invalidValue : invalidValues) {
+            mExpectedException.expect(IllegalArgumentException.class);
+            mExpectedException.expectMessage("Invalid contrast " + String.valueOf(invalidValue) + ", level must be between 0 and 255");
+            ssd1306.setContrast(invalidValue);
+            Mockito.verify(mI2c, Mockito.never()).writeRegByte(0x00, (byte) 0x81);
+            Mockito.verify(mI2c, Mockito.never()).writeRegByte(0x00, (byte) 66);
+            Mockito.reset(mExpectedException);
+        }
+    }
+}


### PR DESCRIPTION
The ssd1306 allows you to set the contrast on a display with 256 unique steps. This allows you to set it.