### PR TITLE
[Driver] Add support for ZXSensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Driver | Type | Usage (add to your gradle dependencies) | Note
 [driver-sensehat](sensehat) | metadriver for the Sense HAT | `compile 'com.google.android.things.contrib:driver-sensehat:0.2'` | [sample](https://github.com/androidthings/drivers-samples/tree/master/sensehat) [changelog](sensehat/CHANGELOG.md)
 [driver-ssd1306](ssd1306) | OLED display | `compile 'com.google.android.things.contrib:driver-ssd1306:0.4'` | [sample](https://github.com/androidthings/drivers-samples/tree/master/ssd1306) [changelog](ssd1306/CHANGELOG.md)
 [driver-tm1637](tm1637) | 4-digit numeric segment display | `compile 'com.google.android.things.contrib:driver-tm1637:0.2'` | [sample](https://github.com/androidthings/drivers-samples/tree/master/tm1637) [changelog](tm1637/CHANGELOG.md)
+[driver-zxsensor](zxsensor) | Sparkfun ZX Sensor | `compile 'com.google.android.things.contrib:driver-zxsensor:0.2'` | [sample](https://github.com/androidthings/drivers-samples/tree/master/zxsensor) [changelog](zxsensor/CHANGELOG.md)
+
 <!-- DRIVER_LIST_END -->
 
 License

--- a/zxsensor/CHANGELOG.md
+++ b/zxsensor/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Change Log
+
+## [0.1] - 2017-07-19
+- initial version

--- a/zxsensor/README.md
+++ b/zxsensor/README.md
@@ -1,0 +1,85 @@
+ZX Sensor driver for Android Things
+===================================
+
+This driver supports speaker and piezo buzzer peripherals using the PWM protocol.
+
+NOTE: these drivers are not production-ready. They are offered as sample
+implementations of Android Things user space drivers for common peripherals
+as part of the Developer Preview release. There is no guarantee
+of correctness, completeness or robustness.
+
+How to use the driver
+---------------------
+
+### Gradle dependency
+
+To use the `zxsensor` driver, simply add the line below to your project's `build.gradle`,
+where `<version>` matches the last version of the driver available on [jcenter][jcenter].
+
+```
+dependencies {
+    compile 'com.google.android.things.contrib:driver-pwmspeaker:<version>'
+}
+```
+
+### Sample usage
+
+```java
+import com.google.android.things.contrib.driver.pwmspeaker.Speaker;
+
+// Access the speaker:
+
+Speaker mSpeaker;
+
+try {
+    mSpeaker = new Speaker(pwmPinName);
+} catch (IOException e) {
+    // couldn't configure the speaker...
+}
+
+// Make it play:
+
+try {
+    mSpeaker.play(440 /* tone */);
+} catch (IOException e) {
+    // error setting speaker
+}
+
+// Stop a currently playing tone:
+
+try {
+    mSpeaker.stop();
+} catch (IOException e) {
+    // error stopping speaker
+}
+
+// Close the speaker when finished:
+
+try {
+    mSpeaker.close();
+} catch (IOException e) {
+    // error closing speaker
+}
+```
+
+License
+-------
+
+Copyright 2016 Google Inc.
+
+Licensed to the Apache Software Foundation (ASF) under one or more contributor
+license agreements.  See the NOTICE file distributed with this work for
+additional information regarding copyright ownership.  The ASF licenses this
+file to you under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy of
+the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+
+[jcenter]: https://bintray.com/google/androidthings/contrib-driver-pwmspeaker/_latestVersion

--- a/zxsensor/README.md
+++ b/zxsensor/README.md
@@ -18,48 +18,53 @@ where `<version>` matches the last version of the driver available on [jcenter][
 
 ```
 dependencies {
-    compile 'com.google.android.things.contrib:driver-pwmspeaker:<version>'
+    compile 'com.google.android.things.contrib:driver-zxsensor:<version>'
 }
 ```
 
 ### Sample usage
 
 ```java
-import com.google.android.things.contrib.driver.pwmspeaker.Speaker;
+import com.google.android.things.contrib.driver.zxsensor.ZxSensor;
+import com.google.android.things.contrib.driver.zxsensor.ZxSensorUart;
 
-// Access the speaker:
+// Access the ZXSensor (choose I2C or UART) here we show UART:
 
-Speaker mSpeaker;
-
-try {
-    mSpeaker = new Speaker(pwmPinName);
-} catch (IOException e) {
-    // couldn't configure the speaker...
-}
-
-// Make it play:
+ZxSensorUart zxSensorUart;
 
 try {
-    mSpeaker.play(440 /* tone */);
+    zxSensorUart = ZxSensor.Factory.openViaUart(BoardDefaults.getUartPin());
 } catch (IOException e) {
-    // error setting speaker
+    throw new IllegalStateException("Can't open, did you use the correct pin name?", e);
 }
+zxSensorUart.setSwipeLeftListener(swipeLeftListener);
+zxSensorUart.setSwipeRightListener(swipeRightListener);
 
-// Stop a currently playing tone:
+ZxSensor.SwipeLeftListener swipeLeftListener = new ZxSensor.SwipeLeftListener() {
+        @Override
+        public void onSwipeLeft(int speed) {
+            Log.d("TUT", "Swipe left detected");
+        }
+    };
 
-try {
-    mSpeaker.stop();
-} catch (IOException e) {
-    // error stopping speaker
-}
+ZxSensor.SwipeRightListener swipeRightListener = new ZxSensor.SwipeRightListener() {
+        @Override
+        public void onSwipeRight(int speed) {
+            Log.d("TUT", "Swipe right detected");
+        }
+    };
 
-// Close the speaker when finished:
+// Start monitoring:
 
-try {
-    mSpeaker.close();
-} catch (IOException e) {
-    // error closing speaker
-}
+zxSensorUart.startMonitoringGestures();
+
+// Stop monitoring:
+
+zxSensorUart.stopMonitoringGestures();
+
+// Close the ZXSensor when finished:
+
+zxSensorUart.close();
 ```
 
 License
@@ -82,4 +87,4 @@ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
 License for the specific language governing permissions and limitations under
 the License.
 
-[jcenter]: https://bintray.com/google/androidthings/contrib-driver-pwmspeaker/_latestVersion
+[jcenter]: https://bintray.com/google/androidthings/contrib-driver-zxsensor/_latestVersion

--- a/zxsensor/README.md
+++ b/zxsensor/README.md
@@ -1,7 +1,7 @@
 ZX Sensor driver for Android Things
 ===================================
 
-This driver supports speaker and piezo buzzer peripherals using the PWM protocol.
+This driver supports ZXSensor peripherals using the I2C and UART protocols.
 
 NOTE: these drivers are not production-ready. They are offered as sample
 implementations of Android Things user space drivers for common peripherals

--- a/zxsensor/build.gradle
+++ b/zxsensor/build.gradle
@@ -14,20 +14,24 @@
  * limitations under the License.
  */
 
-include ':adcv2x'
-include ':apa102'
-include ':button'
-include ':bmx280'
-include ':cap12xx'
-include ':gps'
-include ':ht16k33'
-include ':mma7660fc'
-include ':pwmservo'
-include ':pwmspeaker'
-include ':tm1637'
-include ':ssd1306'
-include ':rainbowhat'
-include ':sensehat'
-include ':zxsensor'
+apply plugin: 'com.android.library'
 
-include ':testingutils'
+android {
+    compileSdkVersion 24
+    buildToolsVersion '24.0.3'
+
+    defaultConfig {
+        minSdkVersion 24
+        targetSdkVersion 24
+        versionCode 1
+        versionName '1.0'
+    }
+}
+
+dependencies {
+    provided 'com.google.android.things:androidthings:0.4-devpreview'
+    compile 'com.android.support:support-annotations:24.2.0'
+
+    testCompile 'junit:junit:4.12'
+    testCompile 'org.mockito:mockito-core:1.10.19'
+}

--- a/zxsensor/gradle.properties
+++ b/zxsensor/gradle.properties
@@ -1,0 +1,2 @@
+TYPE="ZX Sensor"
+ARTIFACT_VERSION=0.1

--- a/zxsensor/publish-settings.gradle
+++ b/zxsensor/publish-settings.gradle
@@ -1,0 +1,1 @@
+rootProject.buildFileName = '../publish.gradle'

--- a/zxsensor/src/main/AndroidManifest.xml
+++ b/zxsensor/src/main/AndroidManifest.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ Copyright 2016 Google Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.google.android.things.contrib.driver.zxsensor">
+    <application>
+        <uses-library android:name="com.google.android.things" />
+    </application>
+</manifest>

--- a/zxsensor/src/main/java/com/google/android/things/contrib/driver/zxsensor/ZxSensor.java
+++ b/zxsensor/src/main/java/com/google/android/things/contrib/driver/zxsensor/ZxSensor.java
@@ -8,6 +8,13 @@ import java.io.IOException;
  */
 public interface ZxSensor extends AutoCloseable {
 
+    void startMonitoringGestures();
+
+    void stopMonitoringGestures();
+
+    @Override
+    void close();
+
     interface IdMessageListener {
         /**
          * This message is used for sensor type identification.

--- a/zxsensor/src/main/java/com/google/android/things/contrib/driver/zxsensor/ZxSensor.java
+++ b/zxsensor/src/main/java/com/google/android/things/contrib/driver/zxsensor/ZxSensor.java
@@ -1,0 +1,147 @@
+package com.google.android.things.contrib.driver.zxsensor;
+
+import java.io.IOException;
+
+/**
+ * https://cdn.sparkfun.com/assets/learn_tutorials/3/4/5/XYZ_Interactive_Technologies_-_ZX_SparkFun_Sensor_Datasheet.pdf
+ * https://cdn.sparkfun.com/assets/learn_tutorials/3/4/5/XYZ_I2C_Registers_v1.zip
+ */
+public interface ZxSensor extends AutoCloseable {
+
+    interface IdMessageListener {
+        /**
+         * This message is used for sensor type identification.
+         * Including hardware and firmware versions.
+         */
+        void onIdMessage(String id);
+    }
+
+    interface RangeListener {
+        /**
+         * Each range is between 0 to 240
+         * the higher the number the closer the object to the
+         * left or right sensor
+         */
+        void onRangeUpdate(int left, int right);
+    }
+
+    interface ZCoordinateListener {
+        /**
+         * Z coordinate is between 0 to 240
+         */
+        void onZCoordinateUpdate(int coordinate);
+    }
+
+    interface XCoordinateListener {
+        /**
+         * X coordinate is between 0 to 240
+         */
+        void onXCoordinateUpdate(int coordinate);
+    }
+
+    interface GestureEventListener {
+        /**
+         * Some sort of gesture was detected
+         */
+        void onGestureEvent();
+    }
+
+    interface PenUpEventListener {
+        /**
+         * Indicates that the reflector moved out of range.
+         */
+        void onPenUp();
+    }
+
+    interface MessageListener extends
+        IdMessageListener,
+        RangeListener,
+        ZCoordinateListener,
+        XCoordinateListener,
+        GestureEventListener,
+        PenUpEventListener {
+        // Helper interface if you want all the messages
+    }
+
+    interface SwipeRightListener {
+        /**
+         * Swipe is the simplest gestural
+         * interaction: the reflector moves in the
+         * right direction over the sensor.
+         * <p>
+         * Speed is reported as a normalized
+         * value between 1 to 10
+         *
+         * @param speed 1 = slow 10 = fast
+         */
+        void onSwipeRight(int speed);
+    }
+
+    interface SwipeLeftListener {
+        /**
+         * Swipe is the simplest gestural
+         * interaction: the reflector moves in the
+         * left direction over the sensor.
+         * <p>
+         * Speed is reported as a normalized
+         * value between 1 to 10
+         *
+         * @param speed 1 = slow 10 = fast
+         */
+        void onSwipeLeft(int speed);
+    }
+
+    interface SwipeDownListener {
+        /**
+         * * Swipe is the simplest gestural
+         * interaction: the reflector moves in a
+         * downward direction over the sensor.
+         * <p>
+         * Speed is reported as a normalized
+         * value between 1 to 10
+         *
+         * @param speed 1 = slow 10 = fast
+         */
+        void onSwipeDown(int speed);
+    }
+
+    interface HoverListener {
+        /**
+         * This gesture is sent when the reflector
+         * stops (hover) over the sensor for few
+         * seconds, then moves in a certain direction.
+         *
+         * @param position where the hover was detected left, right or center
+         */
+        void onHover(HoverPosition position);
+    }
+
+    interface GestureListener extends
+        SwipeRightListener,
+        SwipeLeftListener,
+        SwipeDownListener,
+        HoverListener {
+        // Helper interface if you want all the gestures
+    }
+
+    /**
+     * A descriptor for where the hover was detected
+     */
+    public enum HoverPosition {
+        LEFT, RIGHT, CENTER
+    }
+
+    interface DeviceErrorListener {
+        void onDeviceError(int error);
+    }
+
+    class Factory {
+        public ZxSensorUart openViaUart(String uartBus) throws IOException {
+            return new ZxSensorUart(uartBus);
+        }
+
+        public ZxSensorI2c openViaI2c(String i2cBus, String gpioDataNotifyPin) throws IOException {
+            return new ZxSensorI2c(i2cBus, gpioDataNotifyPin);
+        }
+    }
+}

--- a/zxsensor/src/main/java/com/google/android/things/contrib/driver/zxsensor/ZxSensor.java
+++ b/zxsensor/src/main/java/com/google/android/things/contrib/driver/zxsensor/ZxSensor.java
@@ -136,11 +136,11 @@ public interface ZxSensor extends AutoCloseable {
     }
 
     class Factory {
-        public ZxSensorUart openViaUart(String uartBus) throws IOException {
+        public static ZxSensorUart openViaUart(String uartBus) throws IOException {
             return new ZxSensorUart(uartBus);
         }
 
-        public ZxSensorI2c openViaI2c(String i2cBus, String gpioDataNotifyPin) throws IOException {
+        public static ZxSensorI2c openViaI2c(String i2cBus, String gpioDataNotifyPin) throws IOException {
             return new ZxSensorI2c(i2cBus, gpioDataNotifyPin);
         }
     }

--- a/zxsensor/src/main/java/com/google/android/things/contrib/driver/zxsensor/ZxSensor.java
+++ b/zxsensor/src/main/java/com/google/android/things/contrib/driver/zxsensor/ZxSensor.java
@@ -76,10 +76,8 @@ public interface ZxSensor extends AutoCloseable {
          * interaction: the reflector moves in the
          * right direction over the sensor.
          * <p>
-         * Speed is reported as a normalized
-         * value between 1 to 10
          *
-         * @param speed 1 = slow 10 = fast
+         * @param speed a number corresponding to the speed of the gesture
          */
         void onSwipeRight(int speed);
     }
@@ -90,10 +88,8 @@ public interface ZxSensor extends AutoCloseable {
          * interaction: the reflector moves in the
          * left direction over the sensor.
          * <p>
-         * Speed is reported as a normalized
-         * value between 1 to 10
          *
-         * @param speed 1 = slow 10 = fast
+         * @param speed a number corresponding to the speed of the gesture
          */
         void onSwipeLeft(int speed);
     }
@@ -104,10 +100,8 @@ public interface ZxSensor extends AutoCloseable {
          * interaction: the reflector moves in a
          * downward direction over the sensor.
          * <p>
-         * Speed is reported as a normalized
-         * value between 1 to 10
          *
-         * @param speed 1 = slow 10 = fast
+         * @param speed a number corresponding to the speed of the gesture
          */
         void onSwipeDown(int speed);
     }

--- a/zxsensor/src/main/java/com/google/android/things/contrib/driver/zxsensor/ZxSensorI2c.java
+++ b/zxsensor/src/main/java/com/google/android/things/contrib/driver/zxsensor/ZxSensorI2c.java
@@ -149,10 +149,10 @@ public class ZxSensorI2c implements ZxSensor {
 
     ZxSensorI2c(String i2cBus, String gpioDataNotifyPin) throws IOException {
         this(
-            i2cBus,
-            gpioDataNotifyPin,
-            new PeripheralManagerService().openI2cDevice(i2cBus, 0x10),
-            new PeripheralManagerService().openGpio(gpioDataNotifyPin)
+                i2cBus,
+                gpioDataNotifyPin,
+                new PeripheralManagerService().openI2cDevice(i2cBus, 0x10),
+                new PeripheralManagerService().openGpio(gpioDataNotifyPin)
         );
     }
 
@@ -400,7 +400,7 @@ public class ZxSensorI2c implements ZxSensor {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
         rangeListener = null;
         zCoordinateListener = null;
         xCoordinateListener = null;
@@ -410,7 +410,17 @@ public class ZxSensorI2c implements ZxSensor {
         hoverListener = null;
         messageListener = null;
         gestureListener = null;
-        mDevice.close();
-        mDataNotifyBus.close();
+        try {
+            mDevice.close();
+        } catch (IOException e) {
+            throw new IllegalStateException("Could not close the I2C: " + i2cBus + " connection. " +
+                                                    "You may see errors if you do not power cycle the device.", e);
+        }
+        try {
+            mDataNotifyBus.close();
+        } catch (IOException e) {
+            throw new IllegalStateException("Could not close the GPIO: " + dataNotifyPinName + " connection. " +
+                                                    "You may see errors if you do not power cycle the device.", e);
+        }
     }
 }

--- a/zxsensor/src/main/java/com/google/android/things/contrib/driver/zxsensor/ZxSensorI2c.java
+++ b/zxsensor/src/main/java/com/google/android/things/contrib/driver/zxsensor/ZxSensorI2c.java
@@ -11,7 +11,7 @@ import com.google.android.things.pio.PeripheralManagerService;
 
 import java.io.IOException;
 
-class ZxSensorI2c implements ZxSensor {
+public class ZxSensorI2c implements ZxSensor {
 
     /**
      * 7 ReadOnly HeartBeat: This bit will toggle every time the status register has been read
@@ -127,11 +127,11 @@ class ZxSensorI2c implements ZxSensor {
     private final Gpio mDataNotifyBus;
 
     @Nullable
-    private RangeListener rangeListener;
+    private ZxSensor.RangeListener rangeListener;
     @Nullable
-    private ZCoordinateListener zCoordinateListener;
+    private ZxSensor.ZCoordinateListener zCoordinateListener;
     @Nullable
-    private XCoordinateListener xCoordinateListener;
+    private ZxSensor.XCoordinateListener xCoordinateListener;
     @Nullable
     private ZxSensor.SwipeLeftListener swipeLeftListener;
     @Nullable
@@ -174,15 +174,15 @@ class ZxSensorI2c implements ZxSensor {
         }
     }
 
-    public void setRangeListener(@Nullable RangeListener rangeListener) {
+    public void setRangeListener(@Nullable ZxSensor.RangeListener rangeListener) {
         this.rangeListener = rangeListener;
     }
 
-    public void setzCoordinateListener(@Nullable ZCoordinateListener zCoordinateListener) {
+    public void setzCoordinateListener(@Nullable ZxSensor.ZCoordinateListener zCoordinateListener) {
         this.zCoordinateListener = zCoordinateListener;
     }
 
-    public void setxCoordinateListener(@Nullable XCoordinateListener xCoordinateListener) {
+    public void setxCoordinateListener(@Nullable ZxSensor.XCoordinateListener xCoordinateListener) {
         this.xCoordinateListener = xCoordinateListener;
     }
 
@@ -210,6 +210,7 @@ class ZxSensorI2c implements ZxSensor {
         this.gestureListener = gestureListener;
     }
 
+    @Override
     public void startMonitoringGestures() {
         onI2cDataAvailable = createCallback();
         try {
@@ -388,6 +389,7 @@ class ZxSensorI2c implements ZxSensor {
         }
     }
 
+    @Override
     public void stopMonitoringGestures() {
         try {
             mDataNotifyBus.unregisterGpioCallback(onI2cDataAvailable);

--- a/zxsensor/src/main/java/com/google/android/things/contrib/driver/zxsensor/ZxSensorI2c.java
+++ b/zxsensor/src/main/java/com/google/android/things/contrib/driver/zxsensor/ZxSensorI2c.java
@@ -148,11 +148,19 @@ class ZxSensorI2c implements ZxSensor {
     private GpioCallback onI2cDataAvailable;
 
     ZxSensorI2c(String i2cBus, String gpioDataNotifyPin) throws IOException {
+        this(
+            i2cBus,
+            gpioDataNotifyPin,
+            new PeripheralManagerService().openI2cDevice(i2cBus, 0x10),
+            new PeripheralManagerService().openGpio(gpioDataNotifyPin)
+        );
+    }
+
+    ZxSensorI2c(String i2cBus, String dataNotifyPinName, I2cDevice mDevice, Gpio mDataNotifyBus) {
         this.i2cBus = i2cBus;
-        this.dataNotifyPinName = gpioDataNotifyPin;
-        PeripheralManagerService pioService = new PeripheralManagerService();
-        this.mDevice = pioService.openI2cDevice(i2cBus, 0x10);
-        this.mDataNotifyBus = pioService.openGpio(gpioDataNotifyPin);
+        this.dataNotifyPinName = dataNotifyPinName;
+        this.mDevice = mDevice;
+        this.mDataNotifyBus = mDataNotifyBus;
         configure();
     }
 

--- a/zxsensor/src/main/java/com/google/android/things/contrib/driver/zxsensor/ZxSensorI2c.java
+++ b/zxsensor/src/main/java/com/google/android/things/contrib/driver/zxsensor/ZxSensorI2c.java
@@ -2,7 +2,6 @@ package com.google.android.things.contrib.driver.zxsensor;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.util.Log;
 
 import com.google.android.things.pio.Gpio;
 import com.google.android.things.pio.GpioCallback;
@@ -149,10 +148,10 @@ public class ZxSensorI2c implements ZxSensor {
 
     ZxSensorI2c(String i2cBus, String gpioDataNotifyPin) throws IOException {
         this(
-                i2cBus,
-                gpioDataNotifyPin,
-                new PeripheralManagerService().openI2cDevice(i2cBus, 0x10),
-                new PeripheralManagerService().openGpio(gpioDataNotifyPin)
+            i2cBus,
+            gpioDataNotifyPin,
+            new PeripheralManagerService().openI2cDevice(i2cBus, 0x10),
+            new PeripheralManagerService().openGpio(gpioDataNotifyPin)
         );
     }
 
@@ -232,11 +231,7 @@ public class ZxSensorI2c implements ZxSensor {
             @Override
             public boolean onGpioEdge(Gpio gpio) {
                 try {
-                    byte dataReadyConfiguration = mDevice.readRegByte(DATA_READY_CONFIG);
-                    Log.d("TUT", "drc " + dataReadyConfiguration);
-
                     byte status = mDevice.readRegByte(STATUS);
-                    Log.d("TUT", "Status " + status);
 
                     // (range) Position Data Available
                     if ((status & 0b00000001) == 0b00000001) {
@@ -244,17 +239,14 @@ public class ZxSensorI2c implements ZxSensor {
                     }
                     // Swipe Gesture Available
                     if ((status & 0b00000100) == 0b00000100) {
-                        Log.d("TUT", "SWIPE GESTURE DATA AVAILABLE");
                         handleGesture();
                     }
                     // Hover Gesture Available
                     if ((status & 0b00001000) == 0b000001000) {
-                        Log.d("TUT", "HOVER GESTURE DATA AVAILABLE");
                         handleGesture();
                     }
                     // Hover-Move Gesture Available
                     if ((status & 0b00001000) == 0b000001000) {
-                        Log.d("TUT", "HOVER-Move GESTURE DATA AVAILABLE");
                         handleGesture();
                     }
                 } catch (IOException e) {
@@ -267,9 +259,7 @@ public class ZxSensorI2c implements ZxSensor {
     }
 
     private void handleRanges() throws IOException {
-        Log.d("TUT", "RANGE POSITION DATA AVAILABLE");
         byte zpos = mDevice.readRegByte(Z_POSITION);
-        Log.d("TUT", "ZPos : " + zpos);
         if (messageListener != null) {
             messageListener.onZCoordinateUpdate(zpos);
         }
@@ -277,7 +267,6 @@ public class ZxSensorI2c implements ZxSensor {
             zCoordinateListener.onZCoordinateUpdate(zpos);
         }
         byte xpos = mDevice.readRegByte(X_POSITION);
-        Log.d("TUT", "XPos : " + xpos);
         if (messageListener != null) {
             messageListener.onXCoordinateUpdate(xpos);
         }
@@ -285,9 +274,7 @@ public class ZxSensorI2c implements ZxSensor {
             xCoordinateListener.onXCoordinateUpdate(xpos);
         }
         byte left = mDevice.readRegByte(LEFT_EMITTER_RANGING_DATA);
-        Log.d("TUT", "LRNG : " + left);
         byte right = mDevice.readRegByte(RIGHT_EMITTER_RANGING_DATA);
-        Log.d("TUT", "RRNG : " + right);
 
         if (messageListener != null) {
             messageListener.onRangeUpdate(left, right);
@@ -302,12 +289,9 @@ public class ZxSensorI2c implements ZxSensor {
             messageListener.onGestureEvent();
         }
         byte gesture = mDevice.readRegByte(LAST_DETECTED_GESTURE);
-        Log.d("TUT", "New gesture! " + gesture);
         byte speed = mDevice.readRegByte(LAST_DETECTED_GESTURE_SPEED);
-        Log.d("TUT", "Speed! " + speed);
 
         if (gesture == 0x01) {
-            Log.d("TUT", "Swipe Right");
             if (gestureListener != null) {
                 gestureListener.onSwipeRight(speed);
             }
@@ -315,7 +299,6 @@ public class ZxSensorI2c implements ZxSensor {
                 swipeRightListener.onSwipeRight(speed);
             }
         } else if (gesture == 0x02) {
-            Log.d("TUT", "Swipe Left");
             if (gestureListener != null) {
                 gestureListener.onSwipeLeft(speed);
             }
@@ -323,7 +306,6 @@ public class ZxSensorI2c implements ZxSensor {
                 swipeLeftListener.onSwipeLeft(speed);
             }
         } else if (gesture == 0x03) {
-            Log.d("TUT", "Swipe Down");
             if (gestureListener != null) {
                 gestureListener.onSwipeDown(speed);
             }
@@ -331,7 +313,6 @@ public class ZxSensorI2c implements ZxSensor {
                 swipeDownListener.onSwipeDown(speed);
             }
         } else if (gesture == 0x05) {
-            Log.d("TUT", "Hover");
             if (gestureListener != null) {
                 gestureListener.onHover(ZxSensor.HoverPosition.CENTER);
             }
@@ -339,7 +320,6 @@ public class ZxSensorI2c implements ZxSensor {
                 hoverListener.onHover(ZxSensor.HoverPosition.CENTER);
             }
         } else if (gesture == 0x06) {
-            Log.d("TUT", "Hover Left");
             if (gestureListener != null) {
                 gestureListener.onHover(ZxSensor.HoverPosition.LEFT);
             }
@@ -347,7 +327,6 @@ public class ZxSensorI2c implements ZxSensor {
                 hoverListener.onHover(ZxSensor.HoverPosition.LEFT);
             }
         } else if (gesture == 0x07) {
-            Log.d("TUT", "Hover Right");
             if (gestureListener != null) {
                 gestureListener.onHover(ZxSensor.HoverPosition.RIGHT);
             }
@@ -355,7 +334,6 @@ public class ZxSensorI2c implements ZxSensor {
                 hoverListener.onHover(ZxSensor.HoverPosition.RIGHT);
             }
         } else if (gesture == 0x08) {
-            Log.d("TUT", "Hover Up");
             if (gestureListener != null) {
                 gestureListener.onHover(ZxSensor.HoverPosition.CENTER);
             }
@@ -414,13 +392,13 @@ public class ZxSensorI2c implements ZxSensor {
             mDevice.close();
         } catch (IOException e) {
             throw new IllegalStateException("Could not close the I2C: " + i2cBus + " connection. " +
-                                                    "You may see errors if you do not power cycle the device.", e);
+                                                "You may see errors if you do not power cycle the device.", e);
         }
         try {
             mDataNotifyBus.close();
         } catch (IOException e) {
             throw new IllegalStateException("Could not close the GPIO: " + dataNotifyPinName + " connection. " +
-                                                    "You may see errors if you do not power cycle the device.", e);
+                                                "You may see errors if you do not power cycle the device.", e);
         }
     }
 }

--- a/zxsensor/src/main/java/com/google/android/things/contrib/driver/zxsensor/ZxSensorI2c.java
+++ b/zxsensor/src/main/java/com/google/android/things/contrib/driver/zxsensor/ZxSensorI2c.java
@@ -1,0 +1,392 @@
+package com.google.android.things.contrib.driver.zxsensor;
+
+import android.support.annotation.Nullable;
+import android.util.Log;
+
+import com.google.android.things.pio.Gpio;
+import com.google.android.things.pio.GpioCallback;
+import com.google.android.things.pio.I2cDevice;
+import com.google.android.things.pio.PeripheralManagerService;
+
+import java.io.IOException;
+
+class ZxSensorI2c implements ZxSensor {
+
+    /**
+     * 7 ReadOnly HeartBeat: This bit will toggle every time the status register has been read
+     * 6 ReadOnly Not Used
+     * 5 ReadOnly Edge Detection Event: currently unused, reads 0
+     * 4 ReadOnly Hover-Move Gesture Available: X = gesture Y = gesture
+     * 3 ReadOnly Hover Gesture Available: X = gesture Y = gesture
+     * 2 ReadOnly Swipe Gesture Available: X = gesture Y = gesture
+     * 1 ReadOnly Brightness value overflow: currently unused, reads 0
+     * 0 ReadOnly Position Data Available: X = position Y = coordinate
+     * <p>
+     * Bits, 0,2,3,4. A 1 indicates that new X data is available in the Y registers
+     * Bits, 0,2,3,4. Automatically resets to zero after being read
+     */
+    private static final int STATUS = 0x00;
+    /**
+     * 0x01 = data ready enable
+     * <p>
+     * 7 ReadOnly Not Used
+     * 6 ReadOnly Not Used
+     * 5 ReadWrite Edge Detection
+     * 4 ReadWrite Hover-Move Gestures
+     * 3 ReadWrite Hover Gestures
+     * 2 ReadWrite Swipe Gestures
+     * 1 ReadWrite Coordinate Data available
+     * 0 ReadWrite Ranging Data available
+     * <p>
+     * A '1' in any of these bits will allow the DR pin to assert
+     * when the respective event or gesture occurs.
+     */
+    private static final int DATA_READ_ENABLE = 0x01;
+    private static final byte ENABLE_ALL = (byte) 0b00111111;
+    private static final byte DISABLE_ALL = (byte) 0b00000000;
+    /**
+     * 7 ReadWrite Enable DR: 1 = DR enabled, 0 = DR always negated
+     * 6 ReadWrite Force DR pin to assert (this bit auto-clears): 1 = Force DR pin to assert, 0 = normal DR operation
+     * 5 ReadOnly NotUsed
+     * 4 ReadOnly NotUsed
+     * 3 ReadOnly NotUsed
+     * 2 ReadOnly NotUsed
+     * 1 ReadWrite DataReady pin Edge/Level Select: 1 = DR pin asserts for 1 pulse, 0 = DR pin asserts until STATUS is read
+     * 0 ReadWrite DataReady pin Polarity Select: 1 = DR pin is active-high, 0 = DR pin is active-low
+     */
+    private static final int DATA_READY_CONFIG = 0x02;
+    /**
+     * 7-0 ReadOnly Gesture
+     * <p>
+     * 0x01	Right Swipe
+     * 0x02	Left Swipe
+     * 0x03	Up Swipe
+     * 0x05	Hover
+     * 0x06	Hover-Left
+     * 0x07	Hover-Right
+     * 0x08	Hover-Up
+     * <p>
+     * The most recent gesture appears in this register.
+     * The gesture value remains until a new gesture is detected
+     * The gesture bits in the status register can be used to determine
+     * when to read a new value from this register
+     */
+    private static final int LAST_DETECTED_GESTURE = 0x04;
+    /**
+     * 7-0 ReadOnly Gesture Speed
+     * <p>
+     * The speed of the most recently detected gesture is stored here.
+     * The value remains until a new gesture is detected.
+     */
+    private static final int LAST_DETECTED_GESTURE_SPEED = 0x05;
+    /**
+     * 7-0 ReadOnly X Position
+     * <p>
+     * The most recently calcuated X position is stored in this register
+     */
+    private static final int X_POSITION = 0x08;
+    /**
+     * 7-0 ReadOnly Z Position
+     * <p>
+     * The most recently calcuated Z position is stored in this register
+     */
+    private static final int Z_POSITION = 0x0a;
+    /**
+     * 7-0 ReadOnly Left Emitter Ranging Data
+     * <p>
+     * The left emitter ranging data is stored in this register.
+     */
+    private static final int LEFT_EMITTER_RANGING_DATA = 0x0c;
+    /**
+     * 7-0 ReadOnly Right Emitter Ranging Data
+     * <p>
+     * The right emitter ranging data is stored in this register.
+     */
+    private static final int RIGHT_EMITTER_RANGING_DATA = 0x0e;
+    /**
+     * 7-0 ReadOnly Register Map Version
+     * <p>
+     * This register is used to identify the register map version of attached sensor
+     * All sensors share a register map.
+     * Sensors with the same register map have the same data arrangement
+     * 0x01 = Register Map v1
+     */
+    private static final int REGISTER_MAP_VERSION = 0xfe;
+    /**
+     * 7-0 ReadOnly Sensor Model ID
+     * <p>
+     * This register is used to identify the type of sensor attached.
+     * 0x01 = XZ01
+     */
+    private static final int SENSOR_MODEL = 0xff;
+
+    private final String i2cBus;
+    private final String dataNotifyPinName;
+    private final I2cDevice mDevice;
+    private final Gpio mDataNotifyBus;
+
+    @Nullable
+    private RangeListener rangeListener;
+    @Nullable
+    private ZCoordinateListener zCoordinateListener;
+    @Nullable
+    private XCoordinateListener xCoordinateListener;
+    @Nullable
+    private ZxSensor.SwipeLeftListener swipeLeftListener;
+    @Nullable
+    private ZxSensor.SwipeRightListener swipeRightListener;
+    @Nullable
+    private ZxSensor.SwipeDownListener swipeDownListener;
+    @Nullable
+    private ZxSensor.HoverListener hoverListener;
+    @Nullable
+    private ZxSensor.MessageListener messageListener;
+    @Nullable
+    private ZxSensor.GestureListener gestureListener;
+
+    ZxSensorI2c(String i2cBus, String gpioDataNotifyPin) throws IOException {
+        this.i2cBus = i2cBus;
+        this.dataNotifyPinName = gpioDataNotifyPin;
+        PeripheralManagerService pioService = new PeripheralManagerService();
+        this.mDevice = pioService.openI2cDevice(i2cBus, 0x10);
+        this.mDataNotifyBus = pioService.openGpio(gpioDataNotifyPin);
+        configure();
+    }
+
+    private void configure() {
+        try {
+            mDataNotifyBus.setActiveType(Gpio.ACTIVE_HIGH);
+            mDataNotifyBus.setDirection(Gpio.DIRECTION_IN);
+            mDataNotifyBus.setEdgeTriggerType(Gpio.EDGE_RISING);
+            mDataNotifyBus.registerGpioCallback(onI2cDataAvailable);
+        } catch (IOException e) {
+            throw new IllegalStateException(dataNotifyPinName + " cannot be configured.", e);
+        }
+    }
+
+    public void setRangeListener(@Nullable RangeListener rangeListener) {
+        this.rangeListener = rangeListener;
+    }
+
+    public void setzCoordinateListener(@Nullable ZCoordinateListener zCoordinateListener) {
+        this.zCoordinateListener = zCoordinateListener;
+    }
+
+    public void setxCoordinateListener(@Nullable XCoordinateListener xCoordinateListener) {
+        this.xCoordinateListener = xCoordinateListener;
+    }
+
+    public void setSwipeLeftListener(@Nullable ZxSensor.SwipeLeftListener swipeLeftListener) {
+        this.swipeLeftListener = swipeLeftListener;
+    }
+
+    public void setSwipeRightListener(@Nullable ZxSensor.SwipeRightListener swipeRightListener) {
+        this.swipeRightListener = swipeRightListener;
+    }
+
+    public void setSwipeDownListener(@Nullable ZxSensor.SwipeDownListener swipeDownListener) {
+        this.swipeDownListener = swipeDownListener;
+    }
+
+    public void setHoverListener(@Nullable ZxSensor.HoverListener hoverListener) {
+        this.hoverListener = hoverListener;
+    }
+
+    public void setMessageListener(@Nullable ZxSensor.MessageListener messageListener) {
+        this.messageListener = messageListener;
+    }
+
+    public void setGestureListener(@Nullable ZxSensor.GestureListener gestureListener) {
+        this.gestureListener = gestureListener;
+    }
+
+    public void startMonitoringGestures() {
+        try {
+            mDevice.writeRegByte(DATA_READ_ENABLE, ENABLE_ALL);
+        } catch (IOException e) {
+            throw new IllegalStateException("Cannot listen for input from " + i2cBus, e);
+        }
+    }
+
+    private final GpioCallback onI2cDataAvailable = new GpioCallback() {
+        @Override
+        public boolean onGpioEdge(Gpio gpio) {
+            try {
+                byte dataReadyConfiguration = mDevice.readRegByte(DATA_READY_CONFIG);
+                Log.d("TUT", "drc " + dataReadyConfiguration);
+
+                byte status = mDevice.readRegByte(STATUS);
+                Log.d("TUT", "Status " + status);
+
+                // (range) Position Data Available
+                if ((status & 0b00000001) == 0b00000001) {
+                    handleRanges();
+                }
+                // Swipe Gesture Available
+                if ((status & 0b00000100) == 0b00000100) {
+                    Log.d("TUT", "SWIPE GESTURE DATA AVAILABLE");
+                    handleGesture();
+                }
+                // Hover Gesture Available
+                if ((status & 0b00001000) == 0b000001000) {
+                    Log.d("TUT", "HOVER GESTURE DATA AVAILABLE");
+                    handleGesture();
+                }
+                // Hover-Move Gesture Available
+                if ((status & 0b00001000) == 0b000001000) {
+                    Log.d("TUT", "HOVER-Move GESTURE DATA AVAILABLE");
+                    handleGesture();
+                }
+            } catch (IOException e) {
+                throw new IllegalStateException("Cannot read device data.", e);
+            }
+
+            return true;
+        }
+    };
+
+    private void handleRanges() throws IOException {
+        Log.d("TUT", "RANGE POSITION DATA AVAILABLE");
+        byte zpos = mDevice.readRegByte(Z_POSITION);
+        Log.d("TUT", "ZPos : " + zpos);
+        if (messageListener != null) {
+            messageListener.onZCoordinateUpdate(zpos);
+        }
+        if (zCoordinateListener != null) {
+            zCoordinateListener.onZCoordinateUpdate(zpos);
+        }
+        byte xpos = mDevice.readRegByte(X_POSITION);
+        Log.d("TUT", "XPos : " + xpos);
+        if (messageListener != null) {
+            messageListener.onXCoordinateUpdate(xpos);
+        }
+        if (xCoordinateListener != null) {
+            xCoordinateListener.onXCoordinateUpdate(xpos);
+        }
+        byte left = mDevice.readRegByte(LEFT_EMITTER_RANGING_DATA);
+        Log.d("TUT", "LRNG : " + left);
+        byte right = mDevice.readRegByte(RIGHT_EMITTER_RANGING_DATA);
+        Log.d("TUT", "RRNG : " + right);
+
+        if (messageListener != null) {
+            messageListener.onRangeUpdate(left, right);
+        }
+        if (rangeListener != null) {
+            rangeListener.onRangeUpdate(left, right);
+        }
+    }
+
+    private void handleGesture() throws IOException {
+        if (messageListener != null) {
+            messageListener.onGestureEvent();
+        }
+        byte gesture = mDevice.readRegByte(LAST_DETECTED_GESTURE);
+        Log.d("TUT", "New gesture! " + gesture);
+        byte speed = mDevice.readRegByte(LAST_DETECTED_GESTURE_SPEED);
+        Log.d("TUT", "Speed! " + speed);
+
+        if (gesture == 0x01) {
+            Log.d("TUT", "Swipe Right");
+            if (gestureListener != null) {
+                gestureListener.onSwipeRight(speed);
+            }
+            if (swipeRightListener != null) {
+                swipeRightListener.onSwipeRight(speed);
+            }
+        } else if (gesture == 0x02) {
+            Log.d("TUT", "Swipe Left");
+            if (gestureListener != null) {
+                gestureListener.onSwipeLeft(speed);
+            }
+            if (swipeLeftListener != null) {
+                swipeLeftListener.onSwipeLeft(speed);
+            }
+        } else if (gesture == 0x03) {
+            Log.d("TUT", "Swipe Down");
+            if (gestureListener != null) {
+                gestureListener.onSwipeDown(speed);
+            }
+            if (swipeDownListener != null) {
+                swipeDownListener.onSwipeDown(speed);
+            }
+        } else if (gesture == 0x05) {
+            Log.d("TUT", "Hover");
+            if (gestureListener != null) {
+                gestureListener.onHover(ZxSensor.HoverPosition.CENTER);
+            }
+            if (hoverListener != null) {
+                hoverListener.onHover(ZxSensor.HoverPosition.CENTER);
+            }
+        } else if (gesture == 0x06) {
+            Log.d("TUT", "Hover Left");
+            if (gestureListener != null) {
+                gestureListener.onHover(ZxSensor.HoverPosition.LEFT);
+            }
+            if (hoverListener != null) {
+                hoverListener.onHover(ZxSensor.HoverPosition.LEFT);
+            }
+        } else if (gesture == 0x07) {
+            Log.d("TUT", "Hover Right");
+            if (gestureListener != null) {
+                gestureListener.onHover(ZxSensor.HoverPosition.RIGHT);
+            }
+            if (hoverListener != null) {
+                hoverListener.onHover(ZxSensor.HoverPosition.RIGHT);
+            }
+        } else if (gesture == 0x08) {
+            Log.d("TUT", "Hover Up");
+            if (gestureListener != null) {
+                gestureListener.onHover(ZxSensor.HoverPosition.CENTER);
+            }
+            if (hoverListener != null) {
+                hoverListener.onHover(ZxSensor.HoverPosition.CENTER);
+            }
+        }
+    }
+
+    public void forceAnUpdate() {
+        try {
+            mDevice.writeRegByte(DATA_READY_CONFIG, (byte) 0b01000001);
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    public byte getRegisterVersion() {
+        try {
+            return mDevice.readRegByte(REGISTER_MAP_VERSION);
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    public byte getModelId() {
+        try {
+            return mDevice.readRegByte(SENSOR_MODEL);
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    public void stopMonitoringGestures() {
+        try {
+            mDevice.writeRegByte(DATA_READ_ENABLE, DISABLE_ALL);
+        } catch (IOException e) {
+            throw new IllegalStateException("Cannot listen for input from " + i2cBus, e);
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        rangeListener = null;
+        zCoordinateListener = null;
+        xCoordinateListener = null;
+        swipeLeftListener = null;
+        swipeRightListener = null;
+        swipeDownListener = null;
+        hoverListener = null;
+        messageListener = null;
+        gestureListener = null;
+        mDataNotifyBus.unregisterGpioCallback(onI2cDataAvailable);
+    }
+}

--- a/zxsensor/src/main/java/com/google/android/things/contrib/driver/zxsensor/ZxSensorI2c.java
+++ b/zxsensor/src/main/java/com/google/android/things/contrib/driver/zxsensor/ZxSensorI2c.java
@@ -158,7 +158,6 @@ class ZxSensorI2c implements ZxSensor {
             mDataNotifyBus.setActiveType(Gpio.ACTIVE_HIGH);
             mDataNotifyBus.setDirection(Gpio.DIRECTION_IN);
             mDataNotifyBus.setEdgeTriggerType(Gpio.EDGE_RISING);
-            mDataNotifyBus.registerGpioCallback(onI2cDataAvailable);
         } catch (IOException e) {
             throw new IllegalStateException(dataNotifyPinName + " cannot be configured.", e);
         }
@@ -202,6 +201,7 @@ class ZxSensorI2c implements ZxSensor {
 
     public void startMonitoringGestures() {
         try {
+            mDataNotifyBus.registerGpioCallback(onI2cDataAvailable);
             mDevice.writeRegByte(DATA_READ_ENABLE, ENABLE_ALL);
         } catch (IOException e) {
             throw new IllegalStateException("Cannot listen for input from " + i2cBus, e);
@@ -370,6 +370,7 @@ class ZxSensorI2c implements ZxSensor {
 
     public void stopMonitoringGestures() {
         try {
+            mDataNotifyBus.unregisterGpioCallback(onI2cDataAvailable);
             mDevice.writeRegByte(DATA_READ_ENABLE, DISABLE_ALL);
         } catch (IOException e) {
             throw new IllegalStateException("Cannot listen for input from " + i2cBus, e);
@@ -387,6 +388,7 @@ class ZxSensorI2c implements ZxSensor {
         hoverListener = null;
         messageListener = null;
         gestureListener = null;
-        mDataNotifyBus.unregisterGpioCallback(onI2cDataAvailable);
+        mDevice.close();
+        mDataNotifyBus.close();
     }
 }

--- a/zxsensor/src/main/java/com/google/android/things/contrib/driver/zxsensor/ZxSensorUart.java
+++ b/zxsensor/src/main/java/com/google/android/things/contrib/driver/zxsensor/ZxSensorUart.java
@@ -1,0 +1,345 @@
+package com.google.android.things.contrib.driver.zxsensor;
+
+import android.support.annotation.Nullable;
+
+import com.google.android.things.pio.PeripheralManagerService;
+import com.google.android.things.pio.UartDevice;
+import com.google.android.things.pio.UartDeviceCallback;
+
+import java.io.IOException;
+
+class ZxSensorUart implements ZxSensor {
+
+    private final String bus;
+    private final UartDevice mDevice;
+
+    @Nullable
+    private ZxSensor.IdMessageListener idMessageListener;
+    @Nullable
+    private RangeListener rangeListener;
+    @Nullable
+    private ZCoordinateListener zCoordinateListener;
+    @Nullable
+    private XCoordinateListener xCoordinateListener;
+    @Nullable
+    private GestureEventListener gestureEventListener;
+    @Nullable
+    private PenUpEventListener penUpEventListener;
+    @Nullable
+    private ZxSensor.SwipeLeftListener swipeLeftListener;
+    @Nullable
+    private ZxSensor.SwipeRightListener swipeRightListener;
+    @Nullable
+    private ZxSensor.SwipeDownListener swipeDownListener;
+    @Nullable
+    private ZxSensor.HoverListener hoverListener;
+    @Nullable
+    private ZxSensor.MessageListener messageListener;
+    @Nullable
+    private ZxSensor.GestureListener gestureListener;
+    @Nullable
+    private DeviceErrorListener deviceErrorListener;
+
+    ZxSensorUart(String bus) throws IOException {
+        this(bus, new PeripheralManagerService().openUartDevice(bus));
+    }
+
+    ZxSensorUart(String bus, UartDevice device) throws IOException {
+        this.bus = bus;
+        this.mDevice = device;
+        configure();
+    }
+
+    private void configure() {
+        try {
+            mDevice.setBaudrate(115200);
+            mDevice.setDataSize(8);
+            mDevice.setParity(UartDevice.PARITY_NONE);
+            mDevice.setStopBits(1);
+        } catch (IOException e) {
+            throw new IllegalStateException(bus + " cannot be configured.", e);
+        }
+
+    }
+
+    public void setIdMessageListener(@Nullable ZxSensor.IdMessageListener idMessageListener) {
+        this.idMessageListener = idMessageListener;
+    }
+
+    public void setRangeListener(@Nullable RangeListener rangeListener) {
+        this.rangeListener = rangeListener;
+    }
+
+    public void setzCoordinateListener(@Nullable ZCoordinateListener zCoordinateListener) {
+        this.zCoordinateListener = zCoordinateListener;
+    }
+
+    public void setxCoordinateListener(@Nullable XCoordinateListener xCoordinateListener) {
+        this.xCoordinateListener = xCoordinateListener;
+    }
+
+    public void setGestureEventListener(@Nullable GestureEventListener gestureEventListener) {
+        this.gestureEventListener = gestureEventListener;
+    }
+
+    public void setPenUpEventListener(@Nullable PenUpEventListener penUpEventListener) {
+        this.penUpEventListener = penUpEventListener;
+    }
+
+    public void setSwipeLeftListener(@Nullable ZxSensor.SwipeLeftListener swipeLeftListener) {
+        this.swipeLeftListener = swipeLeftListener;
+    }
+
+    public void setSwipeRightListener(@Nullable ZxSensor.SwipeRightListener swipeRightListener) {
+        this.swipeRightListener = swipeRightListener;
+    }
+
+    public void setSwipeDownListener(@Nullable ZxSensor.SwipeDownListener swipeDownListener) {
+        this.swipeDownListener = swipeDownListener;
+    }
+
+    public void setHoverListener(@Nullable ZxSensor.HoverListener hoverListener) {
+        this.hoverListener = hoverListener;
+    }
+
+    public void setMessageListener(@Nullable ZxSensor.MessageListener messageListener) {
+        this.messageListener = messageListener;
+    }
+
+    public void setGestureListener(@Nullable ZxSensor.GestureListener gestureListener) {
+        this.gestureListener = gestureListener;
+    }
+
+    public void setDeviceErrorListener(@Nullable DeviceErrorListener errorListener) {
+        this.deviceErrorListener = errorListener;
+    }
+
+    public void startMonitoringGestures() {
+        try {
+            mDevice.registerUartDeviceCallback(onUartBusHasData);
+        } catch (IOException e) {
+            throw new IllegalStateException("Cannot listen for input from " + bus, e);
+        }
+    }
+
+    private final UartDeviceCallback onUartBusHasData = new UartDeviceCallback() {
+        @Override
+        public boolean onUartDeviceDataAvailable(UartDevice uart) {
+            try {
+                byte[] buffer = new byte[4];
+                while (uart.read(buffer, buffer.length) > 0) {
+                    byte messageCode = buffer[0];
+                    switch (messageCode) {
+                        case (byte) 0xFF:
+                            handlePenUpMessage();
+                            break;
+                        case (byte) 0xFE:
+                            handleRangesMessage(buffer[1], buffer[2]);
+                            break;
+                        case (byte) 0xFA:
+                            handleXCoordinateMessage(buffer[1]);
+                            break;
+                        case (byte) 0xFB:
+                            handleZCoordinateMessage(buffer[1]);
+                            break;
+                        case (byte) 0xFC:
+                            handleGestureEventMessage(buffer[1], buffer[2], buffer[2]);
+                            break;
+                        case (byte) 0xF1:
+                            handleIdMessage(buffer[1], buffer[2], buffer[3]);
+                            break;
+                        default:
+                            // do nothing, fail silently
+                            break;
+                    }
+                }
+
+            } catch (IOException e) {
+                throw new IllegalStateException("Cannot read device data.", e);
+            }
+            return true;
+        }
+
+        @Override
+        public void onUartDeviceError(UartDevice uart, int error) {
+            if (deviceErrorListener != null) {
+                deviceErrorListener.onDeviceError(error);
+            }
+        }
+    };
+
+    /**
+     * Indicates that the reflector moved out
+     * of range. Mark the end of a data
+     * stream.
+     */
+    private void handlePenUpMessage() {
+        if (messageListener != null) {
+            messageListener.onPenUp();
+        }
+        if (penUpEventListener != null) {
+            penUpEventListener.onPenUp();
+        }
+    }
+
+    /**
+     * Each range is represented by 1
+     * unsigned byte with a range between
+     * 0 to 240
+     * <p>
+     * These numbers get larger as the reflector
+     * gets closer to the sensor so they are
+     * more a measure of reflected energy.
+     * They are used to calculate the Z and X coordinates
+     *
+     * @param leftRangeByte  higher as object closer
+     * @param rightRangeByte higher as object closer
+     */
+    private void handleRangesMessage(byte leftRangeByte, byte rightRangeByte) {
+        int left = (leftRangeByte & 0xff) + 120;
+        int right = (rightRangeByte & 0xff) + 120;
+        if (messageListener != null) {
+            messageListener.onRangeUpdate(left, right);
+        }
+        if (rangeListener != null) {
+            rangeListener.onRangeUpdate(left, right);
+        }
+    }
+
+    /**
+     * X coordinate is represented as a
+     * signed byte with a 120 bias.
+     *
+     * @param byteCoordinate coordinate
+     */
+    private void handleXCoordinateMessage(byte byteCoordinate) {
+        int coordinate = (byteCoordinate & 0xff) + 120;
+        if (messageListener != null) {
+            messageListener.onXCoordinateUpdate(coordinate);
+        }
+        if (xCoordinateListener != null) {
+            xCoordinateListener.onXCoordinateUpdate(coordinate);
+        }
+    }
+
+    /**
+     * Z coordinate is represented as an
+     * unsigned byte between 0 to 240
+     *
+     * @param byteCoordinate coordinate
+     */
+    private void handleZCoordinateMessage(byte byteCoordinate) {
+        int coordinate = (byteCoordinate & 0xff) + 120;
+        if (messageListener != null) {
+            messageListener.onZCoordinateUpdate(coordinate);
+        }
+        if (zCoordinateListener != null) {
+            zCoordinateListener.onZCoordinateUpdate(coordinate);
+        }
+    }
+
+    /**
+     * The first byte represents the gesture
+     * code. The additional byte encode
+     * parameters associated with the
+     * gesture (i.e. speed)
+     *
+     * @param gesture  code of the type of gesture
+     * @param position position of the hover event
+     * @param speed    1 = slow, 10 = fast
+     */
+    private void handleGestureEventMessage(byte gesture, byte position, byte speed) {
+        if (messageListener != null) {
+            messageListener.onGestureEvent();
+        }
+        if (gestureEventListener != null) {
+            gestureEventListener.onGestureEvent();
+        }
+
+        if (gesture == 0x01) {
+            if (gestureListener != null) {
+                gestureListener.onSwipeRight(speed);
+            }
+            if (swipeRightListener != null) {
+                swipeRightListener.onSwipeRight(speed);
+            }
+        } else if (gesture == 0x02) {
+            if (gestureListener != null) {
+                gestureListener.onSwipeLeft(speed);
+            }
+            if (swipeLeftListener != null) {
+                swipeLeftListener.onSwipeLeft(speed);
+            }
+        } else if (gesture == 0x03) {
+            if (gestureListener != null) {
+                gestureListener.onSwipeDown(speed);
+            }
+            if (swipeDownListener != null) {
+                swipeDownListener.onSwipeDown(speed);
+            }
+        } else if (gesture == 0x15) {
+            if (position == 1) {
+                if (gestureListener != null) {
+                    gestureListener.onHover(ZxSensor.HoverPosition.RIGHT);
+                }
+                if (hoverListener != null) {
+                    hoverListener.onHover(ZxSensor.HoverPosition.RIGHT);
+                }
+            } else if (position == 2) {
+                if (gestureListener != null) {
+                    gestureListener.onHover(ZxSensor.HoverPosition.LEFT);
+                }
+                if (hoverListener != null) {
+                    hoverListener.onHover(ZxSensor.HoverPosition.LEFT);
+                }
+            } else {
+                if (gestureListener != null) {
+                    gestureListener.onHover(ZxSensor.HoverPosition.CENTER);
+                }
+                if (hoverListener != null) {
+                    hoverListener.onHover(ZxSensor.HoverPosition.CENTER);
+                }
+            }
+        }
+    }
+
+    /**
+     * This message is used for sensor type
+     * identification.
+     *
+     * @param sensorType      sensor type
+     * @param hardwareVersion hardware version
+     * @param firmwareVersion firmware version
+     */
+    private void handleIdMessage(byte sensorType, byte hardwareVersion, byte firmwareVersion) {
+        String id = sensorType + "/" + hardwareVersion + "/" + firmwareVersion;
+        if (messageListener != null) {
+            messageListener.onIdMessage(id);
+        }
+        if (idMessageListener != null) {
+            idMessageListener.onIdMessage(id);
+        }
+    }
+
+    public void stopMonitoringGestures() {
+        mDevice.unregisterUartDeviceCallback(onUartBusHasData);
+    }
+
+    @Override
+    public void close() throws IOException {
+        idMessageListener = null;
+        rangeListener = null;
+        zCoordinateListener = null;
+        xCoordinateListener = null;
+        gestureEventListener = null;
+        penUpEventListener = null;
+        swipeLeftListener = null;
+        swipeRightListener = null;
+        swipeDownListener = null;
+        hoverListener = null;
+        messageListener = null;
+        gestureListener = null;
+        deviceErrorListener = null;
+        mDevice.close();
+    }
+}

--- a/zxsensor/src/main/java/com/google/android/things/contrib/driver/zxsensor/ZxSensorUart.java
+++ b/zxsensor/src/main/java/com/google/android/things/contrib/driver/zxsensor/ZxSensorUart.java
@@ -9,7 +9,7 @@ import com.google.android.things.pio.UartDeviceCallback;
 
 import java.io.IOException;
 
-class ZxSensorUart implements ZxSensor {
+public class ZxSensorUart implements ZxSensor {
 
     private final String bus;
     private final UartDevice mDevice;
@@ -117,6 +117,7 @@ class ZxSensorUart implements ZxSensor {
 
     private UartDeviceCallback onUartBusHasData;
 
+    @Override
     public void startMonitoringGestures() {
         onUartBusHasData = createCallback();
         try {
@@ -128,7 +129,7 @@ class ZxSensorUart implements ZxSensor {
 
     /**
      * We create it like this because otherwise the class is untestable
-     *
+     * <p>
      * https://issuetracker.google.com/issues/37133681
      */
     @NonNull
@@ -333,12 +334,13 @@ class ZxSensorUart implements ZxSensor {
         }
     }
 
+    @Override
     public void stopMonitoringGestures() {
         mDevice.unregisterUartDeviceCallback(onUartBusHasData);
     }
 
     @Override
-    public void close() throws IOException {
+    public void close() {
         idMessageListener = null;
         rangeListener = null;
         zCoordinateListener = null;

--- a/zxsensor/src/main/java/com/google/android/things/contrib/driver/zxsensor/ZxSensorUart.java
+++ b/zxsensor/src/main/java/com/google/android/things/contrib/driver/zxsensor/ZxSensorUart.java
@@ -259,7 +259,7 @@ public class ZxSensorUart implements ZxSensor {
      *
      * @param gesture  code of the type of gesture
      * @param position position of the hover event
-     * @param speed    1 = slow, 10 = fast
+     * @param speed    a number corresponding to the speed of the gesture
      */
     private void handleGestureEventMessage(byte gesture, byte position, byte speed) {
         if (messageListener != null) {

--- a/zxsensor/src/main/java/com/google/android/things/contrib/driver/zxsensor/ZxSensorUart.java
+++ b/zxsensor/src/main/java/com/google/android/things/contrib/driver/zxsensor/ZxSensorUart.java
@@ -354,6 +354,11 @@ public class ZxSensorUart implements ZxSensor {
         messageListener = null;
         gestureListener = null;
         deviceErrorListener = null;
-        mDevice.close();
+        try {
+            mDevice.close();
+        } catch (IOException e) {
+            throw new IllegalStateException("Could not close the UART: " + bus + " connection. " +
+                                                    "You may see errors if you do not power cycle the device.", e);
+        }
     }
 }

--- a/zxsensor/src/test/java/com/google/android/things/contrib/driver/zxsensor/ZxSensorI2cTest.java
+++ b/zxsensor/src/test/java/com/google/android/things/contrib/driver/zxsensor/ZxSensorI2cTest.java
@@ -1,5 +1,28 @@
 package com.google.android.things.contrib.driver.zxsensor;
 
+import com.google.android.things.pio.GpioDriver;
+import com.google.android.things.pio.I2cDevice;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
 public class ZxSensorI2cTest {
 
+    @Mock
+    private I2cDevice mockDevice;
+    @Mock
+    private GpioDriver mockDriver;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void name() throws Exception {
+        new ZxSensorI2c("a", "b", mockDevice, mockDriver);
+
+    }
 }

--- a/zxsensor/src/test/java/com/google/android/things/contrib/driver/zxsensor/ZxSensorI2cTest.java
+++ b/zxsensor/src/test/java/com/google/android/things/contrib/driver/zxsensor/ZxSensorI2cTest.java
@@ -1,5 +1,6 @@
 package com.google.android.things.contrib.driver.zxsensor;
 
+import com.google.android.things.pio.Gpio;
 import com.google.android.things.pio.GpioDriver;
 import com.google.android.things.pio.I2cDevice;
 
@@ -8,12 +9,14 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import static org.mockito.Mockito.verify;
+
 public class ZxSensorI2cTest {
 
     @Mock
     private I2cDevice mockDevice;
     @Mock
-    private GpioDriver mockDriver;
+    private GpioDriver mockDataNotify;
 
     @Before
     public void setUp() throws Exception {
@@ -21,8 +24,23 @@ public class ZxSensorI2cTest {
     }
 
     @Test
-    public void name() throws Exception {
-        new ZxSensorI2c("a", "b", mockDevice, mockDriver);
+    public void dataNotifyPinIsActiveHigh() throws Exception {
+        new ZxSensorI2c("i2c", "gpio", mockDevice, mockDataNotify);
 
+        verify(mockDataNotify).setActiveType(Gpio.ACTIVE_HIGH);
+    }
+
+    @Test
+    public void dataNotifyPinIsAnInput() throws Exception {
+        new ZxSensorI2c("i2c", "gpio", mockDevice, mockDataNotify);
+
+        verify(mockDataNotify).setDirection(Gpio.DIRECTION_IN);
+    }
+
+    @Test
+    public void dataNotifyPinTriggersOnTheLeadingEdge() throws Exception {
+        new ZxSensorI2c("i2c", "gpio", mockDevice, mockDataNotify);
+
+        verify(mockDataNotify).setEdgeTriggerType(Gpio.EDGE_RISING);
     }
 }

--- a/zxsensor/src/test/java/com/google/android/things/contrib/driver/zxsensor/ZxSensorI2cTest.java
+++ b/zxsensor/src/test/java/com/google/android/things/contrib/driver/zxsensor/ZxSensorI2cTest.java
@@ -1,0 +1,5 @@
+package com.google.android.things.contrib.driver.zxsensor;
+
+public class ZxSensorI2cTest {
+
+}

--- a/zxsensor/src/test/java/com/google/android/things/contrib/driver/zxsensor/ZxSensorUartTest.java
+++ b/zxsensor/src/test/java/com/google/android/things/contrib/driver/zxsensor/ZxSensorUartTest.java
@@ -1,0 +1,32 @@
+package com.google.android.things.contrib.driver.zxsensor;
+
+import com.google.android.things.pio.UartDevice;
+import com.google.android.things.pio.UartDeviceCallback;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.verify;
+
+public class ZxSensorUartTest {
+
+    @Mock
+    private UartDevice mockDevice;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void startMonitor_registersWithBus() throws Exception {
+        ZxSensorUart sensor = new ZxSensorUart("any", mockDevice);
+
+        sensor.startMonitoringGestures();
+
+        verify(mockDevice).registerUartDeviceCallback(any(UartDeviceCallback.class));
+    }
+}

--- a/zxsensor/src/test/java/com/google/android/things/contrib/driver/zxsensor/ZxSensorUartTest.java
+++ b/zxsensor/src/test/java/com/google/android/things/contrib/driver/zxsensor/ZxSensorUartTest.java
@@ -1,14 +1,12 @@
 package com.google.android.things.contrib.driver.zxsensor;
 
 import com.google.android.things.pio.UartDevice;
-import com.google.android.things.pio.UartDeviceCallback;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.verify;
 
 public class ZxSensorUartTest {
@@ -22,11 +20,39 @@ public class ZxSensorUartTest {
     }
 
     @Test
-    public void startMonitor_registersWithBus() throws Exception {
-        ZxSensorUart sensor = new ZxSensorUart("any", mockDevice);
+    public void baudRateMatchesDatasheet() throws Exception {
+        new ZxSensorUart("", mockDevice);
 
-        sensor.startMonitoringGestures();
+        verify(mockDevice).setBaudrate(115200);
+    }
 
-        verify(mockDevice).registerUartDeviceCallback(any(UartDeviceCallback.class));
+    @Test
+    public void commsDataSizeMatchesDatasheet() throws Exception {
+        new ZxSensorUart("", mockDevice);
+
+        verify(mockDevice).setDataSize(8);
+    }
+
+    @Test
+    public void parityBitMatchesDatasheet() throws Exception {
+        new ZxSensorUart("", mockDevice);
+
+        verify(mockDevice).setParity(UartDevice.PARITY_NONE);
+    }
+
+    @Test
+    public void stopBitMatchesDatasheet() throws Exception {
+        new ZxSensorUart("", mockDevice);
+
+        verify(mockDevice).setStopBits(1);
+    }
+
+    @Test
+    public void deviceIsClosedWhenClosing() throws Exception {
+        ZxSensorUart uart = new ZxSensorUart("", mockDevice);
+
+        uart.close();
+
+        verify(mockDevice).close();
     }
 }


### PR DESCRIPTION
https://learn.sparkfun.com/tutorials/zx-distance-and-gesture-sensor-hookup-guide

https://cdn.sparkfun.com/assets/learn_tutorials/3/4/5/XYZ_Interactive_Technologies_-_ZX_SparkFun_Sensor_Datasheet.pdf

Allows all gestures to be listened for from the ZXSensor on UART or I2C

```java
import com.google.android.things.contrib.driver.zxsensor.ZxSensor;
import com.google.android.things.contrib.driver.zxsensor.ZxSensorUart;

// Access the ZXSensor (choose I2C or UART) here we show UART:

ZxSensorUart zxSensorUart;

try {
    zxSensorUart = ZxSensor.Factory.openViaUart(BoardDefaults.getUartPin());
} catch (IOException e) {
    throw new IllegalStateException("Can't open, did you use the correct pin name?", e);
}
zxSensorUart.setSwipeLeftListener(swipeLeftListener);
zxSensorUart.setSwipeRightListener(swipeRightListener);

ZxSensor.SwipeLeftListener swipeLeftListener = new ZxSensor.SwipeLeftListener() {
        @Override
        public void onSwipeLeft(int speed) {
            Log.d("TUT", "Swipe left detected");
        }
    };

ZxSensor.SwipeRightListener swipeRightListener = new ZxSensor.SwipeRightListener() {
        @Override
        public void onSwipeRight(int speed) {
            Log.d("TUT", "Swipe right detected");
        }
    };

// Start monitoring:

zxSensorUart.startMonitoringGestures();

// Stop monitoring:

zxSensorUart.stopMonitoringGestures();

// Close the ZXSensor when finished:

zxSensorUart.close();
```

Anything else you need to know?
I've also done a `driver-sample`, once this PR is merged and released the driver sample will compile https://github.com/androidthings/drivers-samples/pull/13

In Action:

![ezgif-4-bb393678bc](https://user-images.githubusercontent.com/655860/28745577-ecd3982c-7472-11e7-8201-a9515996645e.gif)
