### PR TITLE
Update readme to suggest BGR instead of RGB

### DIFF
--- a/apa102/README.md
+++ b/apa102/README.md
@@ -32,7 +32,7 @@ import com.google.android.things.contrib.driver.apa102.Apa102;
 Apa102 mApa102;
 
 try {
-    mApa102 = new Apa102(spiBusName, Apa102.Mode.RGB);
+    mApa102 = new Apa102(spiBusName, Apa102.Mode.BGR);
 } catch (IOException e) {
     // couldn't configure the device...
 }


### PR DESCRIPTION
On an imx7d board at-least, If you try to send Color.X to this library it should expect it in BGR not RGB. This is more apparent if you use a compound color like Color.YELLOW where the effect will be more obvious.