### PR TITLE
Fix typo

### DIFF
--- a/bmx280/src/main/java/com/google/android/things/contrib/driver/bmx280/Bmx280.java
+++ b/bmx280/src/main/java/com/google/android/things/contrib/driver/bmx280/Bmx280.java
@@ -72,7 +72,7 @@ public class Bmx280 implements AutoCloseable {
      */
     public static final float MIN_HUM_RH = 0f;
     /**
-     * Maximum temperature in RH the sensor can measure.
+     * Maximum humidity in RH the sensor can measure.
      */
     public static final float MAX_HUM_RH = 100f;
     /**


### PR DESCRIPTION
Fix a fairly obvious typo likely caused by copy-pasting code and only
making one out of two necessary changes.