### PR TITLE
Fixed readLedStatus to return current LED status rather than transition status

### DIFF
--- a/cap12xx/src/main/java/com/google/android/things/contrib/driver/cap12xx/Cap12xx.java
+++ b/cap12xx/src/main/java/com/google/android/things/contrib/driver/cap12xx/Cap12xx.java
@@ -657,6 +657,21 @@ public class Cap12xx implements AutoCloseable {
      */
     private byte readLedStatus() throws IOException {
         assertLedSupport();
+        return mDevice.readRegByte(REG_LED_CONTROL);
+    }
+
+    /**
+     * Read the transition status of all LEDs as a bitmask.
+     * Each bit is set to "0" if the LED is currently transitioning,
+     * or if the General Status INT bit is cleared,
+     * and "1" if it has finished transitioning.
+     *
+     * @return Bitmask containing the status of all LEDs.
+     *
+     * @throws IOException
+     */
+    private byte readLedTransitionStatus() throws IOException {
+        assertLedSupport();
         return mDevice.readRegByte(REG_LED_STATUS);
     }
 


### PR DESCRIPTION
Working from https://cdn-shop.adafruit.com/datasheets/CAP1188.pdf, page 43 gives an overview of the LED Status register - currently used in this library to get the current status of LEDs - and describes it as "The LED Status Registers indicate when an LED has completed its configured behavior"

IE: if you set up an LED to transition/fade slowly between on/off states then this register will indicate when that transition has completed.

I have corrected `readLedStatus()` to read the `REG_LED_CONTROL` register which will correctly reflect the current desired state of the LED, although it will not always represent the *actual* state of the LED since it may be transitioning.

I have preserved the original transition status functionality in `readLedTransitionStatus()` and better documented its expected behaviour.

This was tested on a Pimoroni Drum HAT/Cap1188- however this required another tweak to pass a custom i2c address which I will submit in a separate PR.